### PR TITLE
Fix LPA*

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,13 +66,13 @@ add_library(${PROJECT_NAME}
 #================================================================================
 
 # Correctness Test Script
-# add_executable(test2d_image examples/test2d_image.cpp)
-# target_link_libraries(test2d_image ${PROJECT_NAME} ${OpenCV_LIBS})
-# install(TARGETS test2d_image RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
-# 
-# add_executable(test_cycle examples/test_cycle.cpp)
-# target_link_libraries(test_cycle ${PROJECT_NAME} ${OpenCV_LIBS})
-# install(TARGETS test_cycle RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+add_executable(test2d_image examples/test2d_image.cpp)
+target_link_libraries(test2d_image ${PROJECT_NAME} ${OpenCV_LIBS})
+install(TARGETS test2d_image RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
+add_executable(test_cycle examples/test_cycle.cpp)
+target_link_libraries(test_cycle ${PROJECT_NAME} ${OpenCV_LIBS})
+install(TARGETS test_cycle RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 #================================================================================
 # Installation

--- a/src/GLS.cpp
+++ b/src/GLS.cpp
@@ -791,14 +791,6 @@ void GLS::rewireSearchTree()
             assert(previousSize - currentSize == 1);
           }
 
-          if (mExtendQueue.hasVertexWithValue(u, mGraph[u].getEstimatedTotalCost()))
-          {
-            mGraph[v].setVisitStatus(VisitStatus::NotVisited);
-            mGraph[v].setCostToCome(std::numeric_limits<double>::max());
-            mGraph[v].setParent(v);
-            continue;
-          }
-
           // Update the vertex.
           mGraph[v].setCostToCome(mGraph[u].getCostToCome() + edgeLength);
           mGraph[v].setParent(u);


### PR DESCRIPTION
Imagine a vertex `u` with two parents `p1` and `p2`. Assume that `p1` has been completely processed, that is expanded and the path to it evaluated. This implies that the shortest path to `p1` has been determined.

Now during LPA*, the current logic ignores rewiring `u` to `p1` if there `p2` is also being rewired along with `u` and `p2` is a better parent *for now*. Now let's say in the subsequent iterations, before `p2` was extended to `u`, `p2` got different parent assigned (which does not percolate to `u` since it is not in the subtree of `p2`), and this makes `p1` a better parent to `u` than `p2` but there is no way of knowing this since `p1` will never be extended.

This code removes the "ignoring". This does not change anything except for removing the bug i.e. it is completely acceptable and correct to do this.